### PR TITLE
Rename VBox template to Hypervisor

### DIFF
--- a/roles/kraken-state/templates/Hypervisor.extension.json.j2
+++ b/roles/kraken-state/templates/Hypervisor.extension.json.j2
@@ -1,5 +1,5 @@
 {
 {{- '    "apiServer": "' ~ ext.apiServer ~ '",\n' if ext.apiServer is defined else "" -}}
 {{- '    "vmName": "' ~ ext.name ~ '",\n' if ext.name is defined else "" -}}
-    "@type": "type.googleapis.com/VBox.VirtualMachine"
+    "@type": "type.googleapis.com/Hypervisor.VirtualMachine"
 }


### PR DESCRIPTION
Matching the extension change from VBox to Hypervisor via https://github.com/kraken-hpc/kraken-layercake/pull/18.